### PR TITLE
Add viewport meta for mobile web

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="initial-scale=1">
   <title>2017 COSCUP Schedule</title>
   <style>
     html, body, .app-container {

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -10,6 +10,9 @@ const styles = {
   bar: RX.Styles.createViewStyle({
     flexDirection: 'row',
     justifyContent: 'space-around',
+    position: 'fixed',
+    bottom: 0,
+    width: '100%',
     paddingTop: 5,
     paddingBottom: 5,
     backgroundColor: '#fff'

--- a/src/containers/Schedule.js
+++ b/src/containers/Schedule.js
@@ -11,7 +11,8 @@ import { getDateDiff, getWidthByTime, getPickerItems } from '../utils';
 const styles = {
   container: RX.Styles.createViewStyle({
     flex: 1,
-    backgroundColor: cst.BACKGROUND_COLOR
+    backgroundColor: cst.BACKGROUND_COLOR,
+    overflow: 'scroll'
   }),
   scroll: RX.Styles.createScrollViewStyle({
     marginTop: cst.STATUS_BAR_HEIGHT,


### PR DESCRIPTION
## Description
更動viewport，改一下mobile web的適應畫面

- **mobile web 改動 viewport 前後畫面** 
<img style="display: inline-block;" width="250" height="443" src="https://user-images.githubusercontent.com/11704825/28815410-e59a579a-76d3-11e7-8a1a-a6975de5a426.png"><img style="display: inline-block;" width="250" src="https://user-images.githubusercontent.com/11704825/28815528-3f8bd260-76d4-11e7-9be3-7a197e07f018.png">

## Test
測試：可以滑就好
![cos gif](https://user-images.githubusercontent.com/11704825/28815253-4a93e19e-76d3-11e7-8abb-121163c9c558.gif)

## Caveat
完全沒測試 ios, android

## Reviews
@hinxcode 